### PR TITLE
Assets - Creation - Ocultar icono papelera cuando no hay ningún color seleccionado

### DIFF
--- a/packages/components/src/form/ColorInput/ColorInput.js
+++ b/packages/components/src/form/ColorInput/ColorInput.js
@@ -121,6 +121,7 @@ const ColorInput = forwardRef(
     const [opened, setOpened] = useState(false);
     const [inputValue, setInputValue] = useState('');
     const closeRef = useClickOutside(() => setOpened(false));
+    console.log('inputValue', inputValue);
 
     useEffect(() => {
       const isNullWhenClearable = clearable && value === null;
@@ -237,7 +238,7 @@ const ColorInput = forwardRef(
                 )}
               </Box>
             </Popover>
-            {clearable && (
+            {clearable && inputValue && (
               <Box
                 sx={{
                   display: 'flex',


### PR DESCRIPTION
fix(ColorInput): if inputValue is empty, don't show "delete" button.