### PR TITLE
fix(components): Alert prevent jump of line on title in `inline` variant

### DIFF
--- a/packages/components/src/feedback/Alert/Alert.styles.js
+++ b/packages/components/src/feedback/Alert/Alert.styles.js
@@ -73,6 +73,7 @@ const AlertStyles = createStyles((theme, { variant, severity }) => {
       lineHeight: 1.2,
       paddingTop: theme.spacing[2],
       paddingBottom: theme.spacing[2],
+      whiteSpace: variant === 'inline' ? 'nowrap' : 'normal',
     },
     content: {
       ...theme.other.global.content.typo.body.sm,


### PR DESCRIPTION
fix(components): Alert - when variant is "inline", prevent jump of line on title.