### PR TITLE
fix(calendar): show in `EventCell` the calendar's initials

### DIFF
--- a/packages/calendars/src/BigCalendar/components/Event/EventCell.js
+++ b/packages/calendars/src/BigCalendar/components/Event/EventCell.js
@@ -386,6 +386,10 @@ function EventCell(thisprops) {
     avatar.image = emptyPixel;
   }
 
+  if (originalEvent.bgColor !== originalEvent.calendar.bgColor) {
+    avatar.fullName = originalEvent.calendarName;
+  }
+
   let lAvatar = null;
   let rAvatar = null;
 


### PR DESCRIPTION
fix(calendar): EventCell. If event don't have icon or image but is an event asociated with a subject, show originarEvent.calendarName initials instead icon or image.